### PR TITLE
fix: add nolint unusedArguments to incomplete definitions

### DIFF
--- a/PersistentDecomp/DirectSumDecomposition.lean
+++ b/PersistentDecomp/DirectSumDecomposition.lean
@@ -211,6 +211,7 @@ variable {D : DirectSumDecomposition M}
 /-- If `D` is a direct sum decomposition of `M` and for each `N` appearing in `D` we are given a
 direct sum decomposition of `N`, we can construct a refinement of `D` whose underlying set is the
 union of all decompositions of the `N`'s appearing in `D`. -/
+@[nolint unusedArguments]
 def refinement (B : ∀ N ∈ D, Set (PersistenceSubmodule M))
     (hB : ∀ N hN, N = sSup (B N hN)) (hB' : ∀ N hN, sSupIndep (B N hN))
     (hB'' : ∀ N hN, ⊥ ∉ B N hN) : DirectSumDecomposition M where

--- a/PersistentDecomp/DirectSumDecompositionDual.lean
+++ b/PersistentDecomp/DirectSumDecompositionDual.lean
@@ -294,6 +294,7 @@ variable {D : DirectSumDecomposition M}
 
 /--If `D` is a direct sum decomposition of `M` and for each `N` appearing in `S` we are given a
 direct sum decomposition of `N`, we can construct a refinement of `D`.-/
+@[nolint unusedArguments]
 def refinement (B : ∀ N ∈ D, Set (PersistenceSubmodule M))
     (hB : ∀ N hN, N = sSup (B N hN)) (hB' : ∀ N hN, sSupIndep (B N hN))
     (hB'' : ∀ N hN, ⊥ ∉ B N hN) : DirectSumDecomposition M where

--- a/PersistentDecomp/MaximalDecompExists.lean
+++ b/PersistentDecomp/MaximalDecompExists.lean
@@ -59,6 +59,7 @@ notation3:max "M["l"]_[" c "]" => chainBound l c
 
 lemma chainBound_le : M[l] ≤ (Λ I l).val := iInf_le ..
 
+@[nolint unusedArguments]
 noncomputable def limit_elt_mk (hT : IsChain LE.le T) (f : T → PersistenceSubmodule M)
   (h_le : ∀ (I J : T), I ≤ J → f J ≤ f I) (h_mem : ∀ I : T, (f I) ∈ I.val) : (L T) := by
   let f' : (I : T) → (Pone T).obj I := by


### PR DESCRIPTION
## Summary
Add `@[nolint unusedArguments]` to three definitions with incomplete proofs.

## Details
The `unusedArguments` linter flagged unused arguments in:
1. `DirectSumDecomposition.refinement` - unused `hB` and `hB'` parameters
2. `Dual.DirectSumDecomposition.refinement` - unused `hB` and `hB'` parameters
3. `limit_elt_mk` - unused `hT` and `h_le` parameters

Since these definitions have incomplete proofs (using `sorry`), the arguments are likely needed when the proofs are completed. Added nolint attribute rather than removing them.

## Test plan
- ✅ Built `PersistentDecomp.DirectSumDecomposition` successfully
- ✅ Built `PersistentDecomp.DirectSumDecompositionDual` successfully
- ✅ Built `PersistentDecomp.MaximalDecompExists` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)