### PR TITLE
Fix simpNF linter warnings

### DIFF
--- a/PersistentDecomp/BumpFunctor.lean
+++ b/PersistentDecomp/BumpFunctor.lean
@@ -88,12 +88,10 @@ We can also show functoriality in the choice of the element `e`.-/
 
 section API
 
-@[simp]
 lemma Bump_apply_of_mem {x : C} (hx : x ∈ S) :
   (Bump e hz hS).obj x = e := by
   simp only [Bump_obj, hx, ↓reduceIte]
 
-@[simp]
 lemma Bump_apply_of_not_mem {x : C} (hx : x ∉ S) :
   (Bump e hz hS).obj x = z := by
   simp only [Bump_obj, hx, ↓reduceIte]

--- a/PersistentDecomp/DirectSumDecompositionDual.lean
+++ b/PersistentDecomp/DirectSumDecompositionDual.lean
@@ -200,7 +200,6 @@ lemma SendsToUniqueGE (I : DirectSumDecomposition M) (J : DirectSumDecomposition
   let B : I := (RefinementMap I J h N)
   rw [UniqueGE I J N A B (⟨h_le, RefinementMapLE I J h N⟩)]
 
-@[simp]
 lemma RefinmentMapFunctorial (I : DirectSumDecomposition M) (J : DirectSumDecomposition M)
     (K : DirectSumDecomposition M) (hij : IsRefinement J I) (hjk : IsRefinement K J)
     (hik : IsRefinement K I) (N : K) :

--- a/PersistentDecomp/EndoRingIsLocal.lean
+++ b/PersistentDecomp/EndoRingIsLocal.lean
@@ -221,7 +221,7 @@ lemma OneDef : (1 : EndRing C R F) = (𝟙 F) := by
   rfl
 
 @[simp]
-lemma ZeroEndAppIsZero : (ZeroEndomorphism C R F).app = 0 := by
+lemma ZeroEndAppIsZero : (fun X => 0 : ∀ X : C, F.obj X →ₗ[R] F.obj X) = 0 := by
   rfl
 
 @[simp]
@@ -247,11 +247,12 @@ lemma NegDef (θ : EndRing C R F) : -θ = OppEndo C R F θ := by
   rfl
 
 @[simp]
-lemma NegApp (θ : EndRing C R F) (X : C) : (-θ).app X = - (θ.app X) := by
+lemma NegApp (θ : EndRing C R F) (X : C) : (OppEndo C R F θ).app X = - (θ.app X) := by
   rfl
 
 @[simp]
-lemma NegAppModule (θ : EndRing C R F) (X : C) (x : F.obj X) :((-θ).app X) x = - (θ.app X x) := by
+lemma NegAppModule (θ : EndRing C R F) (X : C) (x : F.obj X) :
+    ((OppEndo C R F θ).app X) x = - (θ.app X x) := by
   rfl
 
 @[simp]
@@ -259,7 +260,6 @@ lemma MulDef (e : EndRing C R F) (f : EndRing C R F):
   (e * f) = f ≫ e := by
   rfl
 
-@[simp]
 lemma CompIsComp (e : EndRing C R F) (f : EndRing C R F) (X : C) :
   (e * f).app X = f.app X ≫ e.app X := by
   rfl
@@ -289,8 +289,8 @@ lemma PowEqCompLeft (θ : EndRing C R F) (n : ℕ) : θ^(n+1) = θ ≫ (θ^n) :=
   rfl
 
 @[simp]
-lemma PowEqCompRight (θ : EndRing C R F) (n : ℕ) : θ^(n+1) = (θ^n) ≫ θ := by
-  rw [←MulDef]
+lemma PowEqCompRight (θ : EndRing C R F) (n : ℕ) : θ ≫ (θ^n) = (θ^n) ≫ θ := by
+  rw [←PowEqCompLeft, ←MulDef]
   have h : n = (n+1)-1 := by simp
   nth_rewrite 2 [h]
   rw [mul_pow_sub_one]


### PR DESCRIPTION
## Summary

This PR fixes 8 `simpNF` linter warnings across 3 files.

## Changes

### BumpFunctor.lean
- **`Bump_apply_of_mem`** - Removed `@[simp]` (simp can prove via `Bump_obj` + `ite_true`)
- **`Bump_apply_of_not_mem`** - Removed `@[simp]` (simp can prove via `Bump_obj` + `ite_false`)

### DirectSumDecompositionDual.lean
- **`RefinmentMapFunctorial`** - Removed `@[simp]` (argument `J` cannot be inferred by simp)

### EndoRingIsLocal.lean
- **`ZeroEndAppIsZero`** - Changed LHS to simplified form `fun X => 0`
- **`NegApp`** - Changed LHS from `(-θ).app X` to `(OppEndo C R F θ).app X` 
- **`NegAppModule`** - Same LHS change as NegApp
- **`CompIsComp`** - Removed `@[simp]` (simp can prove via `MulDef` + `NatTrans.comp_app`)
- **`PowEqCompRight`** - Changed LHS from `θ^(n+1)` to `θ ≫ (θ^n)` (already simplified by `PowEqCompLeft`)

## Test plan

- [x] Build completes successfully with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)